### PR TITLE
ML-484 add Keras Applications support

### DIFF
--- a/GNNI.ecl
+++ b/GNNI.ecl
@@ -218,6 +218,79 @@ EXPORT GNNI := MODULE
     RETURN model;
   END;
   /**
+    * Load a Keras Application model with its function definition. Optionally,
+    * also provide a "compile" line with the compilation parameters for the
+    * model.
+    * Keras Application reference: https://keras.io/api/applications/
+    * <p>If no compile line is provided (cdef), then the compile specification
+    * can be provided in a subsequent call to CompileMod (below).
+    * <p> "fname" is for the model/function name for the Keras Application
+    * <p> "fdef" is for the model function definition, i.e. what input parameters can be
+    * supplied.
+    * See GNN/Test/ClassicTest.ecl for an annotated example.
+    * @param sess The session token from a previous call to GetSesion().
+    * @param fname A name of the Keras Application. See "supportedModle" in following DefineKAModel for the list.
+    * @param fdef input parameters passed to the model creation. Reference
+    *        https://keras.io/api/applications/ for each model function parameters.
+    *        A simple usage could be:
+    *          fdef  := '''input_shape=(224,224,3),include_top=True,weights=None,classes=2'''
+    *        (224, 224, 3) is the size of the image. "classes=2" means the images will be classified
+    *        with two labels.
+    * @param cdef (optional) A python string as would be passed to Keras model.compile(...).
+    *         This line should begin with "compile".  Model is implicit here.
+    * @return A model token to be used in subsequent GNNI calls.
+    */
+  EXPORT UNSIGNED4 DefineKAModel(UNSIGNED4 sess, STRING fname, STRING fdef, STRING cdef = '') := FUNCTION
+    SET OF STRING supportedModels := [
+                                //  Year       Size        Depth     Default Shape
+                                //  -----------------------------------------------
+      'Xception',               //  2017        88 MB        126     (229,229,3)
+      'VGG16',                  //  2015       528 MB         23     (224,224,3)
+      'VGG19',                  //  2015       549 MB         26     (224,224,3)
+      'ResNet50',               //  2015        98 MB          -     (224,244,3)
+      'ResNet101',              //  2015       171 MB          -     (224,224,3)
+      'ResNet152',              //  2015       232 MB          -     (224,224,3)
+      'ResNet50V2',             //  2016        98 MB          -     (224,224,3)
+      'ResNet101V2',            //  2016       171 MB          -     (224,224,3)
+      'ResNet152V2',            //  2016       232 MB          -     (224,224,3)
+      'InceptionV3',            //  2016        92 MB        159     (229,229,3)
+      'InceptionResNetV2',      //  2017       215 MB        572     (229,229,3)
+      'MobileNet',              //              16 MB         88     (224,224,3)
+      'MobileNetV2',            //  2018        14 MB         88     (224,224,3)
+      'DenseNet121',            //  2017        33 MB        121     (224,224,3)
+      'DenseNet169',            //  2017        57 MB        169     (224,224,3)
+      'DenseNet1201',           //  2017        80 MB        201     (224,224,3)
+      'NASNetMobile',           //  2018        23 MB          -     (224,224,3)
+      'NASNetLarge',            //  2018       343 MB          -     (331,331,3)
+      'EfficientNetB0',         //  2019        29 MB          -
+      'EfficientNetB1',         //  2019        31 MB          -
+      'EfficientNetB2',         //  2019        36 MB          -
+      'EfficientNetB3',         //  2019        48 MB          -
+      'EfficientNetB4',         //  2019        75 MB          -
+      'EfficientNetB5',         //  2019       118 MB          -
+      'EfficientNetB6',         //  2019       166 MB          -
+      'EfficientNetB7'          //  2019       256 MB          -
+    ];
+    checkModel := ASSERT(fname IN supportedModels, 'Unsupported model ' + fname);
+    mdef1 := DATASET([{0, 1, kStrType.layer, fdef}], kString);
+    mdef2 := DATASET([{0, 2, kStrType.compile, cdef}], kString);
+    mdef := IF(LENGTH(cdef) > 0, mdef1 + mdef2, mdef1);
+    mdefRepl0 := SORT(DISTRIBUTE(mdef, ALL), id, LOCAL);
+    mdefRepl := PROJECT(NOCOMBINE(mdefRepl0), TRANSFORM(RECORDOF(LEFT), SELF.nodeId := nodeId, SELF := LEFT), LOCAL);
+    kstatus := ASSERT(Keras.DefineKAModel(fname, mdefRepl, sess), LENGTH(text) = 0, 'DefineKAModel Exception: ' + text);
+    status := reduceResults(kstatus);
+    // Extract the Keras modelId from the id field of the returned status.  Each node should have the
+    // same model id since they are kept in sync.  So we just use the one from our own node.
+    modelId := kstatus(nodeId = nodeId)[1].id;
+    // We need to generate an GNNI modelId that encompasses both the sequence, and encodes
+    // the Keras model id.
+    // We multiply the modelId by kerasIdFactor and use that as the basis for our returned modelId token.
+    // This allows up to kerasIdFactor operations on each model, which should be enough.
+    modelBase := modelId * kerasIdFactor;
+    model := IF(LENGTH(status) = 0, getToken(sess + modelBase), 0);
+    RETURN model;
+  END;
+  /**
     * DefineFuncModel(...) -- Construct a Keras Functional Model.  This allows construction of
     * complex models that cannot be expressed as a sequential set of layers. These include models with multiple
     * inputs or outputs, or models that use divergence or convergence among different layers.


### PR DESCRIPTION
Reference this link for detail: https://keras.io/api/applications/

Example usage:
```code
modelName := 'MobileNetV2';
fdef := '''input_shape=(224,224,3),include_top=True,weights=None,classes=2''';
compileDef := '''compile(optimizer=tf.keras.optimizers.Adam(),
                 loss=tf.keras.losses.binary_crossentropy,
                 metrics=[tf.keras.metrics.BinaryAccuracy()])
                 ''';
s := GNNI.GetSession();
mod := GNNI.DefineKAModel(s, modelName, fdef, compileDef);
```

Following models work:
MobileNetV2';
      Xception
      NASNetMobile
      DenseNet121
      MobilNetV2

Known failed ones:
1) Dataset too large to output to workunit
   VGG19
   ResNet152V2
   InceptionResNetV2
2) 'numpy.float64' object cannot be interpreted as an integer
   EfficientNet series, for example 'EfficientNetB0'
   https://track.hpccsystems.com/browse/ML-497

